### PR TITLE
Add an update method

### DIFF
--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -136,6 +136,30 @@ pub fn delete(
   MerklePatriciaForestry { root: excluding(key, proof) }
 }
 
+/// **fails** when | the [Proof](#Proof) is invalid
+/// ---            | ---
+/// **fails** when | there's no element in the trie at the given key
+/// ---            | ---
+///
+/// Update an element in the trie with a a new value. This requires a [Proof](#Proof)
+/// of the old element, to ensure its in the list, and a [Proof](#Proof) of the new
+/// element, to re-add it.
+///
+/// Can be thought of as a delete, followed by an insert, but is able to do it with one fewer
+/// membership checks
+pub fn update(
+  self: MerklePatriciaForestry,
+  key: ByteArray,
+  proof: Proof,
+  old_value: ByteArray,
+  new_value: ByteArray,
+) {
+  // TODO: could we do this with a single traversal? `something(key, old_value, new_value, proof) -> (old_root, new_root)`?
+  expect including(key, old_value, proof) == self.root
+  // If we were doing a delete followed by an insert, we'd end up checking the `excluding` again here
+  MerklePatriciaForestry { root: including(key, new_value, proof) }
+}
+
 // -----------------------------------------------------------------------------
 // ----------------------------------------------------------------------- Proof
 // -----------------------------------------------------------------------------

--- a/on-chain/lib/aiken/merkle-patricia-forestry.tests.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.tests.ak
@@ -256,6 +256,22 @@ test example_delete() {
   }
 }
 
+test example_update() {
+  // https://media3.giphy.com/media/Bj5ILhCPm8EQ8/giphy.gif
+  mpf.update(trie(), banana, proof_banana(), "🍌", "🍆") == updated_banana()
+}
+
+test example_idempotent_update() {
+  and {
+    mpf.update(trie(), banana, proof_banana(), "🍌", "🍌") == trie(),
+    mpf.update(updated_banana(), banana, proof_banana(), "🍆", "🍆") == updated_banana(),
+  }
+}
+
+test example_fake_update() fail {
+  mpf.update(without_banana(), banana, proof_banana(), "🍌", "🍆") == updated_banana()
+}
+
 // -------------------- Some notable cases
 
 test example_insert_whatever() {
@@ -467,6 +483,13 @@ fn proof_banana() {
 fn without_banana() {
   mpf.from_root(
     #"557990b1257679f2b8e09c507f2582b0566579a2fc26d0d8a6b59a4a88ef16db",
+  )
+}
+
+// The root hash we get with `banana` mapped to 🍆 instead
+fn updated_banana() {
+  mpf.from_root(
+    #"9057d02799a012a9d47fab6f9f5c43b4b2bf94584b339e3b4d3969fd95d55972"
   )
 }
 


### PR DESCRIPTION
The update method can save two membership checks over a delete followed by an insert, because we don't need to bother calculating / verifying the intermediate root

It doesn't include off-chain code for doing updates because I got intimidated, and it's not as useful to safe computation there lol