### PR TITLE
Update version and aiken add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [off-chain](./off-chain#readme) for usage.
 ### On-chain (Aiken)
 
 ```bash
-aiken use aiken-lang/merkle-patricia-forestry --version 1.0.0
+aiken packages add --version 1.0.1 aiken-lang/merkle-patricia-forestry
 ```
 
 See [on-chain](./on-chain#readme) for usage.


### PR DESCRIPTION
Small change in the README.md. The command `aiken use`doesn't exist in v1.0.29-alpha and the version is now 1.0.1.