### PR TITLE
Add `.get(key)` Function to Trie Class for Retrieving Values by Key

### DIFF
--- a/off-chain/lib/trie.js
+++ b/off-chain/lib/trie.js
@@ -323,6 +323,30 @@ export class Trie {
     return loop(Promise.resolve(this), 0);
   }
 
+  /**
+   * Retrieves the value at the given key from the Trie.
+   *
+   * @param {Buffer|string} key
+   *   The key to search for. Strings are treated as UTF-8 byte buffers.
+   * @returns {Promise<Buffer|undefined>}
+   *   The value at the specified key, or `undefined` if the key is not found.
+   */
+  async get(key) {
+    // Convert the key into a path of nibbles
+    const path = intoPath(key);
+    
+    // Use childAt to find the node corresponding to the path
+    const node = await this.childAt(path);
+    
+    key = typeof key === 'string' ? Buffer.from(key) : key;
+    // If the node is a Leaf and the key matches, return the value
+    if (node instanceof Leaf && node.key.equals(key)) {
+      return node.value;
+    }
+  
+    // Return undefined if no matching node is found
+    return undefined;
+  }
 
   /**
    * Creates a proof of inclusion of a given key in the trie.


### PR DESCRIPTION
#### **Description:**
The current implementation of the `Trie` class supports insertion and deletion of values (`.insert(key, value)` and `.delete(key)`), but it lacks a straightforward method for retrieving a value by its key. Adding a `.get(key)` function would improve the usability of the library by providing an intuitive way to query the trie.

#### **Usage Example:**
```javascript
export function displayValue(value) {
  return buffer.isUtf8(value)
    ? value.toString()
    : value.toString('hex').slice(0, DIGEST_SUMMARY_LENGTH)
}

const trie = await Trie.fromList([
  { key: 'foo', value: 'bar' },
  { key: 'baz', value: 'qux' }
]);

// Retrieve the value at key 'foo'
const value = await trie.get('foo');
console.log(value); // Expected output: <Buffer 62 61 72>
console.log(displayValue(value)); // Expected output: bar
```