### PR TITLE
Non-membership proofs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           node-version: 20.13.1
 
+      - name: 🧰 Setup Aiken
+        uses: aiken-lang/setup-aiken@v1
+        with:
+          version: v1.1.17
+
       - name: 🌍 Install dependencies
         working-directory: off-chain
         run: yarn
@@ -52,10 +57,10 @@ jobs:
       - name: 🧰 Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: 🧰 Install Aiken
+      - name: 🧰 Setup Aiken
         uses: aiken-lang/setup-aiken@v1
         with:
-          version: v1.1.4
+          version: v1.1.17
 
       - name: 📝 Run fmt
         working-directory: on-chain

--- a/off-chain/CHANGELOG.md
+++ b/off-chain/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - Allow [`childAt`](https://github.com/aiken-lang/merkle-patricia-forestry/tree/main/off-chain#triechildatpath-string-promisetrieundefined) to return with intermediate sub-tree when passing an incomplete path.
 
+- Adjust `trie.prove` to now accept an optional (default=`false`) flag: `allowMissing`. When set, it becomes possible to build partial proofs for elements that
+are not in the trie. The proof can in particular be verified in exclusion to prove that the given element isn't in the tree (i.e. non-membership).
+
+- New utility functions for proofs:
+  - [`Proof.fromJSON(key, value, steps): Proof`](https://github.com/aiken-lang/merkle-patricia-forestry/tree/main/off-chain#prooffromjson-key-value-steps-proof) to recover a proof from an already serialized JSON value.
+  - [`Proof.setValue(value)`](https://github.com/aiken-lang/merkle-patricia-forestry/tree/main/off-chain#proofsetvaluevalue) to quickly change the value associated with a proof (without having to re-calculate a whole proof).
+  - [`Proof.toUPLC()`](https://github.com/aiken-lang/merkle-patricia-forestry/tree/main/off-chain#prooftouplc) provides a proof in a textual UPLC format; handy to use with `aiken uplc eval`.
+
 ## v1.2.0 - 2024-10-17
 
 ### Added

--- a/off-chain/README.md
+++ b/off-chain/README.md
@@ -211,7 +211,7 @@ const apple = await trie.childAt(
 
 ### Proving
 
-#### `trie.prove(key: string|Buffer): Promise<Proof>`
+#### `trie.prove(key: string|Buffer, allowMissing?: bool): Promise<Proof>`
 
 Let's get to the exciting part! The whole point of building a Merkle Patricia Forestry is to provide succinct proofs for items. A proof is portable and bound to both:
 
@@ -222,6 +222,14 @@ Proofs are only valid for a precise trie root hash and state. So inserting (resp
 
 ```js
 const proofTangerine = await trie.prove('tangerine');
+// Proof {}
+```
+
+Note that it is possible to create partial proofs (or imply, proof of exclusion) for elements that are not in the trie. This is useful to prove non-membership: verifying the proof in exclusion would yield the current trie root.
+
+```js
+// 'melon' isn't in the Trie, but allowMissing is set `true`
+const proofMelon = await trie.prove('melon', true);
 // Proof {}
 ```
 
@@ -260,6 +268,10 @@ proofBanana.verify(false).equals(previousHash);
 >   return proof.verify(true);
 > }
 > ```
+
+#### `proof.setValue(value)`
+
+Once a proof has been generated for a given key/value element; it is possible to quickly change the value associated with that proof using `.setValue` so as the key -- and the rest of the trie; stay the same.
 
 #### `proof.toJSON(): object`
 
@@ -330,11 +342,36 @@ For convenience, you can also generate Aiken code that works with the on-chain p
 
 ```js
 proofTangerine.toAiken();
-// [
-//   Branch { skip: 0, neighbors: #"17a27bc4ce61078d26372800d331d6b8c4b00255080be66977c78b1554aabf8985c09af929492a871e4fae32d9d5c36e352471c
-// d659bcdb61de08f1722acc3b10eb923b0cbd24df54401d998531feead35a47a99f4deed205de4af81120f976100000000000000000000000000000000000000000000000
-// 00000000000000000" },
-//   Leaf { skip: 0, key: #"9702e39845bfd6e0d0a5b6cb4a3a1c25262528c11bcff857867a50a0670e3a28", value: #"b5898c51c32083e91b8c18c735d0ba74e08
-// f964a20b1639c189d1e8704b78a09" },
-// ]
+```
+
+```aiken
+[
+  Branch {
+    skip: 0,
+    neighbors: #"17a27bc4ce61078d26372800d331d6b8c4b00255080be66977c78b1554aabf8985c09af929492a871e4fae32d9d5c36e352471cd659bcdb61de08f1722acc3b10eb923b0cbd24df54401d998531feead35a47a99f4deed205de4af81120f97610000000000000000000000000000000000000000000000000000000000000000",
+  },
+  Leaf {
+    skip: 0,
+    key: #"9702e39845bfd6e0d0a5b6cb4a3a1c25262528c11bcff857867a50a0670e3a28",
+    value: #"b5898c51c32083e91b8c18c735d0ba74e08f964a20b1639c189d1e8704b78a09",
+  },
+]
+```
+
+#### `proof.toUPLC(): String`
+
+Finally, one can also convert proofs in a textual UPLC format which as currently expected by some tools such as `aiken uplc eval`.
+
+```js
+proofTangerine.toAiken();
+```
+
+```uplc
+(con data
+  (List
+    [ Constr 0 [I 0, B #"17a27bc4ce61078d26372800d331d6b8c4b00255080be66977c78b1554aabf8985c09af929492a871e4fae32d9d5c36e352471cd659bcdb61de08f1722acc3b10eb923b0cbd24df54401d998531feead35a47a99f4deed205de4af81120f97610000000000000000000000000000000000000000000000000000000000000000"]
+    , Constr 2 [I 0, B #"9702e39845bfd6e0d0a5b6cb4a3a1c25262528c11bcff857867a50a0670e3a28", B #"b5898c51c32083e91b8c18c735d0ba74e08f964a20b1639c189d1e8704b78a09"]
+    ]
+  )
+)
 ```

--- a/off-chain/lib/trie.js
+++ b/off-chain/lib/trie.js
@@ -381,10 +381,12 @@ export class Trie {
         throw e;
       }
 
+      /* c8 ignore next 3 */
       if (!(e instanceof assert.AssertionError) ) {
         throw e;
       }
 
+      /* c8 ignore next 3 */
       if (!(e.message ?? "").includes("not in trie")) {
         throw e;
       }
@@ -399,6 +401,7 @@ export class Trie {
           assert(hash.equals(this.hash));
           return proof;
         });
+      /* c8 ignore next 4 */
       } catch (e) {
         await this.save();
         throw e;
@@ -440,6 +443,7 @@ export class Trie {
         return Leaf.deserialise(hash, blob, store);
       case 'Branch':
         return Branch.deserialise(hash, blob, store);
+      /* c8 ignore next 2 */
       default:
         throw new Error(`unexpected blob to deserialise: ${blob?.__kind}: ${blob}`);
     }
@@ -1357,6 +1361,7 @@ export class Proof {
           });
         }
 
+        /* c8 ignore next 2 */
         default:
           throw new Error(`unknown step type ${step.type}`);
       }
@@ -1409,6 +1414,7 @@ export class Proof {
               root: Buffer.from(step.neighbor.root, 'hex'),
             },
           };
+        /* c8 ignore next 2 */
         default:
           throw new Error(`unknown step type ${step.type}`);
       }
@@ -1457,6 +1463,34 @@ export class Proof {
     return this.#steps.map(step => serialisers[step.type](step));
   }
 
+  toUPLC() {
+    const steps = this.toJSON().map(step => {
+        switch (step.type) {
+          case Proof.#TYPE_BRANCH.description: {
+            const skip = `I ${step.skip}`;
+            const neighbors = `B #${step.neighbors}`;
+            return `Constr 0 [${skip}, ${neighbors}]`;
+          }
+          case Proof.#TYPE_FORK.description: {
+            const skip = `I ${step.skip}`;
+            const nibble = `I ${step.neighbor.nibble}`;
+            const prefix = `B #${step.neighbor.prefix}`;
+            const root = `B #${step.neighbor.root}`;
+            const neighbors = `Constr 0 [${nibble}, ${prefix}, ${root}]`;
+            return `Constr 1 [${skip}, ${neighbors}]`;
+          }
+          case Proof.#TYPE_LEAF.description: {
+            const skip = `I ${step.skip}`;
+            const key = `B #${step.neighbor.key}`;
+            const value = `B #${step.neighbor.value}`;
+            return `Constr 2 [${skip}, ${key}, ${value}]`;
+          }
+        }
+    });
+
+    return `(con data (List [${steps.join(", ")}]))`;
+  }
+
 
   /** Serialise the proof as a portable CBOR, ready to be decoded on-chain.
    *
@@ -1503,6 +1537,7 @@ export class Proof {
               cbor.end(),
             ));
           }
+          /* c8 ignore next 2 */
           default:
             throw new Error(`unknown step type ${step.type}`);
         }
@@ -1529,6 +1564,7 @@ export class Proof {
         case Proof.#TYPE_LEAF.description: {
           return `  Leaf { skip: ${step.skip}, key: #"${step.neighbor.key}", value: #"${step.neighbor.value}" },\n`
         }
+        /* c8 ignore next 2 */
         default:
           throw new Error(`unknown step type ${step.type}`);
       }

--- a/off-chain/lib/trie.js
+++ b/off-chain/lib/trie.js
@@ -347,6 +347,7 @@ export class Trie {
     const node = await this.childAt(path);
 
     key = typeof key === 'string' ? Buffer.from(key) : key;
+
     // If the node is a Leaf and the key matches, return the value
     if (node instanceof Leaf && node.key.equals(key)) {
       return node.value;
@@ -356,15 +357,53 @@ export class Trie {
     return undefined;
   }
 
+
   /**
-   * Creates a proof of inclusion of a given key in the trie.
+   * Creates a proof for a given element.
    *
    * @param {Buffer|string} key
+   *  The key for the element
+   * @param {bool} [allowMissing]
+   *  An optional flag to allow building a proof for the element when it's not
+   *  in the trie. This is useful to prove non-membership: verifying the proof
+   *  in exclusion would yield the current trie root.
+   *
    * @return {Promise<Proof>}
-   * @throws {AssertionError} When the value is not in the trie.
+   *
+   * @throws {AssertionError}
+   *  When 'allowMissing' is not set and the key is not in the trie.
    */
-  async prove(key) {
-    return this.walk(intoPath(key));
+  async prove(key, allowMissing = false) {
+    try {
+      return await this.walk(intoPath(key));
+    } catch(e) {
+      if (!allowMissing) {
+        throw e;
+      }
+
+      if (!(e instanceof assert.AssertionError) ) {
+        throw e;
+      }
+
+      if (!(e.message ?? "").includes("not in trie")) {
+        throw e;
+      }
+
+      try {
+        return await this.store.batch(async () => {
+          const hash = this.hash;
+          await tryInsert(this, key, "");
+          const proof = await this.prove(key);
+          proof.setValue(undefined);
+          await tryDelete(this, key);
+          assert(hash.equals(this.hash));
+          return proof;
+        });
+      } catch (e) {
+        await this.save();
+        throw e;
+      }
+    }
   }
 
 
@@ -807,73 +846,7 @@ export class Branch extends Trie {
    */
   async insert(key, value) {
     try {
-      return await this.store.batch(async () => {
-        const loop = async (node, path, parents) => {
-          const prefix = node.prefix.length > 0
-            ? commonPrefix([node.prefix, path])
-            : '';
-
-          path = path.slice(prefix.length);
-
-          const thisNibble = nibble(path[0]);
-
-          await node.fetchChildren();
-
-          if (prefix.length < node.prefix.length) {
-            const newPrefix = node.prefix.slice(prefix.length);
-            const newNibble = nibble(newPrefix[0]);
-
-            assert(thisNibble !== newNibble);
-
-            await node.into(Branch, prefix, {
-              [thisNibble]: await Leaf.from(
-                path.slice(1),
-                key,
-                value,
-                this.store,
-              ),
-              [newNibble]: await Branch.from(
-                node.prefix.slice(prefix.length + 1),
-                node.children,
-                this.store,
-              ),
-            });
-
-            return parents;
-          }
-
-          parents.unshift(node);
-
-          const child = node.children[thisNibble];
-
-          if (child === undefined) {
-            node.children[thisNibble] = await Leaf.from(
-              path.slice(1),
-              key,
-              value,
-              this.store
-            );
-            return parents;
-          }
-
-          if (child instanceof Leaf) {
-            await child.insert(key, value);
-            return parents;
-          } else {
-            return loop(child, path.slice(1), parents);
-          }
-        };
-
-        const parents = await loop(this, intoPath(key), []);
-
-        await parents.reduce(async (task, node) => {
-          await task;
-          node.size += 1;
-          return node.save(node.hash);
-        }, Promise.resolve());
-
-        return this;
-      });
+      return await this.store.batch(() => tryInsert(this, key, value));
     } catch(e) {
       // Ensures that children aren't kept in-memory when an insertion failed.
       await this.save();
@@ -895,70 +868,8 @@ export class Branch extends Trie {
    * @throws {AssertionError} when a value doesn't exists at the given key.
    */
   async delete(key) {
-    key = typeof key === 'string' ? Buffer.from(key) : key;
-
-    function nonEmptyChildren(node) {
-      return node.children.flatMap((n, ix) => n === undefined ? [] : [[n, ix]]);
-    }
-
     try {
-      return await this.store.batch(async () => {
-        const loop = async (node, path) => {
-          if (node instanceof Leaf) {
-            await node.delete(key);
-            return undefined;
-          }
-
-          await this.store.del(node.hash);
-
-          const cursor = node.prefix.length;
-
-          const thisNibble = nibble(path[cursor]);
-
-          await node.fetchChildren();
-
-          const child = await node.children[thisNibble];
-
-          // NOTE: 'loop' returns 'undefined' when the child is a leaf, which means
-          // we've reached the end of the trie. So that node gets effectively deleted.
-          //
-          // Then, because we call _loop_ before doing any further modification, we can
-          // continue knowing that children have already been updated.
-          node.children[thisNibble] = await loop(child, path.slice(cursor + 1));
-
-          node.size -= 1;
-
-          const neighbors = nonEmptyChildren(node);
-
-          // NOTE: We do not allow branches with only one child. So if after modification,
-          // there's only one child left (a.k.a the neighbor), we merge our only child up
-          // with ourself while preserving its stucture for the child may be a Leaf or
-          // another Branch node.
-          if (neighbors.length === 1) {
-            const [neighbor, neighborNibble] = neighbors[0];
-
-            const prefix = [
-              node.prefix,
-              neighborNibble.toString(16),
-              neighbor.prefix,
-            ].join('');
-
-            await this.store.del(neighbor.hash);
-
-            if (neighbor instanceof Leaf) {
-              return node.into(Leaf, prefix, neighbor.key, neighbor.value);
-            }
-
-            node.children = neighbor.children;
-            node.prefix = prefix;
-            node.size = neighbor.size;
-          }
-
-          return node.save();
-        };
-
-        return loop(this, intoPath(key));
-      });
+      return await this.store.batch(() => tryDelete(this, key))
     } catch(e) {
       // Ensures that children aren't kept in-memory when an deletion failed.
       await this.save();
@@ -1096,9 +1007,10 @@ export class Branch extends Trie {
    * @private
    */
   async withChildren(callback) {
-    return callback(await Promise.all(this.children.map(child => child === undefined
-      ? child
-      : this.store.get(child.hash, Trie.deserialise)
+    return callback(await Promise.all(this.children.map(child =>
+      child === undefined
+        ? child
+        : this.store.get(child.hash, Trie.deserialise)
     )));
   }
 
@@ -1227,6 +1139,25 @@ export class Proof {
     this.#steps = steps;
   }
 
+
+  /**
+   * Set or reset the value from the proof; This allows re-using the same proof path
+   * in the same trie, but for different values.
+   *
+   * @param {Buffer|string|undefined} value
+   *   The new value to insert. Strings are treated as UTF-8 byte buffers.
+   *   Setting the proof's value to 'undefined' effectively makes the proof only
+   *   work for exclusion (i.e. testing non-membership).
+   */
+  setValue(value) {
+    if (value === undefined) {
+      this.#value = undefined;
+    } else {
+      this.#value = typeof value === 'string' ? Buffer.from(value) : value;
+    }
+  }
+
+
   /** Add a step in front of the proof. The proof is built recursively from the
    * bottom-up (from the leaves to the root). At each step in the proof, we
    * rewind one level until we reach the root. At each level, we record the
@@ -1300,6 +1231,11 @@ export class Proof {
    *   A resulting hash as a byte buffer, to be compared with a known root.
    */
   verify(includingItem = true) {
+    assert(
+      !(includingItem && this.#value === undefined),
+      "attempted to verify an inclusion proof without value: use 'proof.setValue(..)', or build a new proof."
+    );
+
     const loop = (cursor, ix) => {
       const step = this.#steps[ix];
 
@@ -1429,11 +1365,12 @@ export class Proof {
     return loop(0, 0);
   }
 
+
   /** Deserialize a proof from JSON.
    *
    * @param {Buffer|string} path
    *   The original key being proven. Strings are treated as UTF-8 byte buffers.
-   * @param {Buffer|string} value
+   * @param {Buffer|string|undefined} value
    *   The original value being proven. Strings are treated as UTF-8 byte buffers.
    * @param {Array<Object>} steps
    *   The steps serialized to JSON.
@@ -1477,6 +1414,7 @@ export class Proof {
       }
     }));
   }
+
 
   /** Serialise the proof as a portable JSON.
    *
@@ -1598,4 +1536,177 @@ export class Proof {
 
     return `[\n${steps.join('')}]`;
   }
+}
+
+/**
+ * Like 'insert', but as a raw sequence of operations (outside of any
+ * database batch).
+ *
+ * This is useful to compose it with either another insert, or a delete
+ * operation as part of the same database batch.
+ *
+ * For instance, to obtain a Trie containing a given element and build proofs
+ * from it, while not actually modifying the database even in the event of a
+ * crash / fault.
+ *
+ * @param {Buffer|string} key
+ *   The key to insert. Strings are treated as UTF-8 byte buffers.
+ *
+ * @param {Buffer|string} value
+ *   The value to insert. Strings are treated as UTF-8 byte buffers.
+ *
+ * @returns {Promise<Trie>}
+ *   The modified trie, eventually.
+ *
+ * @throws {AssertionError} when a value already exists at the given key.
+ */
+async function tryInsert(self, key, value) {
+  const loop = async (node, path, parents) => {
+    const prefix = node.prefix.length > 0
+      ? commonPrefix([node.prefix, path])
+      : '';
+
+    path = path.slice(prefix.length);
+
+    const thisNibble = nibble(path[0]);
+
+    await node.fetchChildren();
+
+    if (prefix.length < node.prefix.length) {
+      const newPrefix = node.prefix.slice(prefix.length);
+      const newNibble = nibble(newPrefix[0]);
+
+      assert(thisNibble !== newNibble);
+
+      await node.into(Branch, prefix, {
+        [thisNibble]: await Leaf.from(
+          path.slice(1),
+          key,
+          value,
+          self.store,
+        ),
+        [newNibble]: await Branch.from(
+          node.prefix.slice(prefix.length + 1),
+          node.children,
+          self.store,
+        ),
+      });
+
+      return parents;
+    }
+
+    parents.unshift(node);
+
+    const child = node.children[thisNibble];
+
+    if (child === undefined) {
+      node.children[thisNibble] = await Leaf.from(
+        path.slice(1),
+        key,
+        value,
+        self.store
+      );
+      return parents;
+    }
+
+    if (child instanceof Leaf) {
+      await child.insert(key, value);
+      return parents;
+    } else {
+      return loop(child, path.slice(1), parents);
+    }
+  };
+
+  const parents = await loop(self, intoPath(key), []);
+
+  await parents.reduce(async (task, node) => {
+    await task;
+    node.size += 1;
+    return node.save(node.hash);
+  }, Promise.resolve());
+
+  return self;
+}
+
+/**
+ * Like delete, but as a raw sequence of operations (outside of any database
+ * batch).
+ *
+ * This is useful to compose it with either another delete, or a delete
+ * operation as part of the same database batch.
+ *
+ * For instance, to obtain a Trie containing a given element and build proofs
+ * from it, while not actually modifying the database even in the event of a
+ * crash / fault.
+ *
+ * @param {Buffer|string} key
+ *   The key to insert. Strings are treated as UTF-8 byte buffers.
+ *
+ * @returns {Promise<Trie>}
+ *   The modified trie, eventually.
+ *
+ * @throws {AssertionError} when a value doesn't exists at the given key.
+ */
+async function tryDelete(self, key) {
+  key = typeof key === 'string' ? Buffer.from(key) : key;
+
+  function nonEmptyChildren(node) {
+    return node.children.flatMap((n, ix) => n === undefined ? [] : [[n, ix]]);
+  }
+
+  const loop = async (node, path) => {
+    if (node instanceof Leaf) {
+      await node.delete(key);
+      return undefined;
+    }
+
+    await self.store.del(node.hash);
+
+    const cursor = node.prefix.length;
+
+    const thisNibble = nibble(path[cursor]);
+
+    await node.fetchChildren();
+
+    const child = await node.children[thisNibble];
+
+    // NOTE: 'loop' returns 'undefined' when the child is a leaf, which means
+    // we've reached the end of the trie. So that node gets effectively deleted.
+    //
+    // Then, because we call _loop_ before doing any further modification, we can
+    // continue knowing that children have already been updated.
+    node.children[thisNibble] = await loop(child, path.slice(cursor + 1));
+
+    node.size -= 1;
+
+    const neighbors = nonEmptyChildren(node);
+
+    // NOTE: We do not allow branches with only one child. So if after modification,
+    // there's only one child left (a.k.a the neighbor), we merge our only child up
+    // with ourself while preserving its stucture for the child may be a Leaf or
+    // another Branch node.
+    if (neighbors.length === 1) {
+      const [neighbor, neighborNibble] = neighbors[0];
+
+      const prefix = [
+        node.prefix,
+        neighborNibble.toString(16),
+        neighbor.prefix,
+      ].join('');
+
+      await self.store.del(neighbor.hash);
+
+      if (neighbor instanceof Leaf) {
+        return node.into(Leaf, prefix, neighbor.key, neighbor.value);
+      }
+
+      node.children = neighbor.children;
+      node.prefix = prefix;
+      node.size = neighbor.size;
+    }
+
+    return node.save();
+  };
+
+  return loop(self, intoPath(key));
 }

--- a/on-chain/CHANGELOG.md
+++ b/on-chain/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v2.1.0 - UNRELEASED
+
+### Added
+
+- New function `miss` to verify non-membership for keys using proofs of exclusions.
+
+### Changed
+
+- Fixed proof verification for forks with non-empty prefixes.
+
+### Removed
+
+N/A
+
 ## v2.0.1 - 2025-06-25
 
 ### Added

--- a/on-chain/aiken.lock
+++ b/on-chain/aiken.lock
@@ -24,5 +24,5 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@v2" = [{ secs_since_epoch = 1752100575, nanos_since_epoch = 382729000 }, "64a32283418d58cade34059d3855b857e84505541158c541c460cafa0d355475"]
-"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1752100574, nanos_since_epoch = 973398000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]
+"aiken-lang/fuzz@v2" = [{ secs_since_epoch = 1752328783, nanos_since_epoch = 676493000 }, "64a32283418d58cade34059d3855b857e84505541158c541c460cafa0d355475"]
+"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1752328783, nanos_since_epoch = 294946000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]

--- a/on-chain/aiken.lock
+++ b/on-chain/aiken.lock
@@ -24,5 +24,5 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@v2" = [{ secs_since_epoch = 1752096597, nanos_since_epoch = 94067000 }, "64a32283418d58cade34059d3855b857e84505541158c541c460cafa0d355475"]
-"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1752096596, nanos_since_epoch = 687338000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]
+"aiken-lang/fuzz@v2" = [{ secs_since_epoch = 1752100575, nanos_since_epoch = 382729000 }, "64a32283418d58cade34059d3855b857e84505541158c541c460cafa0d355475"]
+"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1752100574, nanos_since_epoch = 973398000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]

--- a/on-chain/aiken.lock
+++ b/on-chain/aiken.lock
@@ -24,5 +24,5 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@v2" = [{ secs_since_epoch = 1751897594, nanos_since_epoch = 720086000 }, "64a32283418d58cade34059d3855b857e84505541158c541c460cafa0d355475"]
-"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1751897594, nanos_since_epoch = 308302000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]
+"aiken-lang/fuzz@v2" = [{ secs_since_epoch = 1752096597, nanos_since_epoch = 94067000 }, "64a32283418d58cade34059d3855b857e84505541158c541c460cafa0d355475"]
+"aiken-lang/stdlib@v2" = [{ secs_since_epoch = 1752096596, nanos_since_epoch = 687338000 }, "25c8d0802b8266feca04b47933382c5dee3cadb422208a5d3810d9d2df108c2e"]

--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -106,7 +106,10 @@ pub fn is_empty(self: MerklePatriciaForestry) -> Bool {
 /// requires a [Proof](#Proof) of inclusion for the element. The latter can be
 /// obtained off-chain from the whole trie containing the element.
 ///
-/// Returns `False` when the element isn't in the tree.
+/// > [!CAUTION]
+/// > `False` doesn't necessarily indicate that the key IS NOT in the trie.
+/// > It only indicates that it isn't present with the given value. To prove
+/// > exclusion of a key, use [`miss`](#miss).
 pub fn has(
   self: MerklePatriciaForestry,
   key: ByteArray,
@@ -114,6 +117,20 @@ pub fn has(
   proof: Proof,
 ) -> Bool {
   including(key, value, proof) == self.root
+}
+
+/// since | <code>1.2.0</code>
+/// ---   | ---
+///
+/// Test whether a key is missing from the trie. This requires a
+/// [Proof](#Proof) of exclusion for the element. The latter can be obtained
+/// off-chain from the whole trie containing the element.
+///
+/// > [!CAUTION]
+/// > `False` doesn't necessarily indicate that the element IS in the trie.
+/// > To prove inclusion, use [`has`](#has).
+pub fn miss(self: MerklePatriciaForestry, key: ByteArray, proof: Proof) -> Bool {
+  excluding(key, proof) == self.root
 }
 
 // # Modifying

--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -156,17 +156,6 @@ pub fn insert(
   MerklePatriciaForestry { root: including(key, value, proof) }
 }
 
-/// A version of 'insert' that unwraps the opaque arguments, to allow being exported.
-fn insert_ffi(
-  self: ByteArray,
-  key: ByteArray,
-  value: ByteArray,
-  proof: Proof,
-) -> ByteArray {
-  expect excluding(key, proof) == self
-  including(key, value, proof)
-}
-
 /// since | <code>1.0.0</code>
 /// ---   | ---
 ///
@@ -186,17 +175,6 @@ pub fn delete(
 ) -> MerklePatriciaForestry {
   expect including(key, value, proof) == self.root
   MerklePatriciaForestry { root: excluding(key, proof) }
-}
-
-/// A version of 'delete' that unwraps the opaque arguments, to allow being exported.
-pub fn delete_ffi(
-  self: ByteArray,
-  key: ByteArray,
-  value: ByteArray,
-  proof: Proof,
-) -> ByteArray {
-  expect including(key, value, proof) == self
-  excluding(key, proof)
 }
 
 /// since          | <code>1.1.0</code>
@@ -288,6 +266,12 @@ fn including(key: ByteArray, value: ByteArray, proof: Proof) -> ByteArray {
   do_including(blake2b_256(key), blake2b_256(value), 0, proof)
 }
 
+test including_empty_proof() {
+  let (k, v) = ("foo", "bar")
+  let path = blake2b_256(k)
+  including(k, v, []) == combine(suffix(path, 0), blake2b_256(v))
+}
+
 fn do_including(
   path: ByteArray,
   value: ByteArray,
@@ -335,6 +319,10 @@ fn do_including(
 /// So this mainly changes the last step.
 fn excluding(key: ByteArray, proof: Proof) -> ByteArray {
   do_excluding(blake2b_256(key), 0, proof)
+}
+
+test excluding_empty_proof() {
+  excluding("foo", []) == empty.root
 }
 
 fn do_excluding(path: ByteArray, cursor: Int, proof: Proof) -> ByteArray {
@@ -455,4 +443,61 @@ fn do_fork(
       combine(neighbor.prefix, neighbor.root),
     ),
   )
+}
+
+// -----------------------------------------------------------------------------
+// -------------------------------------------------- Foreign Function Interface
+// -----------------------------------------------------------------------------
+
+/// A version of 'has' that unwraps the opaque arguments, to allow being exported.
+fn has_ffi(
+  self: ByteArray,
+  key: ByteArray,
+  value: ByteArray,
+  proof: Proof,
+) -> Bool {
+  including(key, value, proof) == self
+}
+
+test disable_unused_warning_has_ffi() fail {
+  has_ffi("", "", "", [])
+}
+
+/// A version of 'miss' that unwraps the opaque arguments, to allow being exported.
+fn miss_ffi(self: ByteArray, key: ByteArray, proof: Proof) -> Bool {
+  excluding(key, proof) == self
+}
+
+test disable_unused_warning_miss_ffi() fail {
+  miss_ffi("", "", [])
+}
+
+/// A version of 'insert' that unwraps the opaque arguments, to allow being exported.
+fn insert_ffi(
+  self: ByteArray,
+  key: ByteArray,
+  value: ByteArray,
+  proof: Proof,
+) -> ByteArray {
+  expect excluding(key, proof) == self
+  including(key, value, proof)
+}
+
+test disable_unused_warning_insert_ffi() fail {
+  insert_ffi("", "", "", []) == ""
+}
+
+/// A version of 'delete' that unwraps the opaque arguments, to allow being exported.
+fn delete_ffi(
+  self: ByteArray,
+  key: ByteArray,
+  value: ByteArray,
+  proof: Proof,
+) -> ByteArray {
+  expect including(key, value, proof) == self
+  excluding(key, proof)
+}
+
+test disable_unused_warning_delete_ffi() fail {
+  delete_ffi("", "", "", []) == ""
 }

--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -259,25 +259,25 @@ fn do_including(
     [] -> combine(suffix(path, cursor), value)
 
     [Branch { skip, neighbors }, ..steps] -> {
-      let nextCursor = cursor + 1 + skip
-      let root = do_including(path, value, nextCursor, steps)
+      let nextCursor = cursor + skip
+      let root = do_including(path, value, nextCursor + 1, steps)
       do_branch(path, cursor, nextCursor, root, neighbors)
     }
 
     [Fork { skip, neighbor }, ..steps] -> {
-      let nextCursor = cursor + 1 + skip
-      let root = do_including(path, value, nextCursor, steps)
+      let nextCursor = cursor + skip
+      let root = do_including(path, value, nextCursor + 1, steps)
       do_fork(path, cursor, nextCursor, root, neighbor)
     }
 
     [Leaf { skip, key, value: neighborValue }, ..steps] -> {
-      let nextCursor = cursor + 1 + skip
-      let root = do_including(path, value, nextCursor, steps)
+      let nextCursor = cursor + skip
+      let root = do_including(path, value, nextCursor + 1, steps)
 
       let neighbor =
         Neighbor {
-          prefix: suffix(key, nextCursor),
-          nibble: nibble(key, nextCursor - 1),
+          prefix: suffix(key, nextCursor + 1),
+          nibble: nibble(key, nextCursor),
           root: neighborValue,
         }
 
@@ -303,8 +303,8 @@ fn do_excluding(path: ByteArray, cursor: Int, proof: Proof) -> ByteArray {
     [] -> null_hash
 
     [Branch { skip, neighbors }, ..steps] -> {
-      let nextCursor = cursor + 1 + skip
-      let root = do_excluding(path, nextCursor, steps)
+      let nextCursor = cursor + skip
+      let root = do_excluding(path, nextCursor + 1, steps)
       do_branch(path, cursor, nextCursor, root, neighbors)
     }
 
@@ -347,21 +347,21 @@ fn do_excluding(path: ByteArray, cursor: Int, proof: Proof) -> ByteArray {
     }
 
     [Fork { skip, neighbor }, ..steps] -> {
-      let nextCursor = cursor + 1 + skip
-      let root = do_excluding(path, nextCursor, steps)
+      let nextCursor = cursor + skip
+      let root = do_excluding(path, nextCursor + 1, steps)
       do_fork(path, cursor, nextCursor, root, neighbor)
     }
 
     [Leaf { key, value, .. }] -> combine(suffix(key, cursor), value)
 
     [Leaf { skip, key, value }, ..steps] -> {
-      let nextCursor = cursor + 1 + skip
-      let root = do_excluding(path, nextCursor, steps)
+      let nextCursor = cursor + skip
+      let root = do_excluding(path, nextCursor + 1, steps)
 
       let neighbor =
         Neighbor {
-          prefix: suffix(key, nextCursor),
-          nibble: nibble(key, nextCursor - 1),
+          prefix: suffix(key, nextCursor + 1),
+          nibble: nibble(key, nextCursor),
           root: value,
         }
 
@@ -381,9 +381,9 @@ fn do_branch(
   root: ByteArray,
   neighbors: ByteArray,
 ) -> ByteArray {
-  let branch = nibble(path, nextCursor - 1)
+  let branch = nibble(path, nextCursor)
 
-  let prefix = nibbles(path, cursor, nextCursor - 1)
+  let prefix = nibbles(path, cursor, nextCursor)
 
   combine(
     prefix,
@@ -405,9 +405,9 @@ fn do_fork(
   root: ByteArray,
   neighbor: Neighbor,
 ) -> ByteArray {
-  let branch = nibble(path, nextCursor - 1)
+  let branch = nibble(path, nextCursor)
 
-  let prefix = nibbles(path, cursor, nextCursor - 1)
+  let prefix = nibbles(path, cursor, nextCursor)
 
   expect branch != neighbor.nibble
 

--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -385,16 +385,12 @@ fn do_branch(
 
   let prefix = nibbles(path, cursor, next_cursor)
 
+  let select =
+    slice_bytearray(_, blake2b_256_digest_size, neighbors)
+
   combine(
     prefix,
-    merkle_16(
-      branch,
-      root,
-      slice_bytearray(0, blake2b_256_digest_size, neighbors),
-      slice_bytearray(32, blake2b_256_digest_size, neighbors),
-      slice_bytearray(64, blake2b_256_digest_size, neighbors),
-      slice_bytearray(96, blake2b_256_digest_size, neighbors),
-    ),
+    merkle_16(branch, root, select(0), select(32), select(64), select(96)),
   )
 }
 

--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -259,29 +259,29 @@ fn do_including(
     [] -> combine(suffix(path, cursor), value)
 
     [Branch { skip, neighbors }, ..steps] -> {
-      let nextCursor = cursor + skip
-      let root = do_including(path, value, nextCursor + 1, steps)
-      do_branch(path, cursor, nextCursor, root, neighbors)
+      let next_cursor = cursor + skip
+      let root = do_including(path, value, next_cursor + 1, steps)
+      do_branch(path, cursor, next_cursor, root, neighbors)
     }
 
     [Fork { skip, neighbor }, ..steps] -> {
-      let nextCursor = cursor + skip
-      let root = do_including(path, value, nextCursor + 1, steps)
-      do_fork(path, cursor, nextCursor, root, neighbor)
+      let next_cursor = cursor + skip
+      let root = do_including(path, value, next_cursor + 1, steps)
+      do_fork(path, cursor, next_cursor, root, neighbor)
     }
 
-    [Leaf { skip, key, value: neighborValue }, ..steps] -> {
-      let nextCursor = cursor + skip
-      let root = do_including(path, value, nextCursor + 1, steps)
+    [Leaf { skip, key, value: neighbor_value }, ..steps] -> {
+      let next_cursor = cursor + skip
+      let root = do_including(path, value, next_cursor + 1, steps)
 
       let neighbor =
         Neighbor {
-          prefix: suffix(key, nextCursor + 1),
-          nibble: nibble(key, nextCursor),
-          root: neighborValue,
+          prefix: suffix(key, next_cursor + 1),
+          nibble: nibble(key, next_cursor),
+          root: neighbor_value,
         }
 
-      do_fork(path, cursor, nextCursor, root, neighbor)
+      do_fork(path, cursor, next_cursor, root, neighbor)
     }
   }
 }
@@ -303,9 +303,9 @@ fn do_excluding(path: ByteArray, cursor: Int, proof: Proof) -> ByteArray {
     [] -> null_hash
 
     [Branch { skip, neighbors }, ..steps] -> {
-      let nextCursor = cursor + skip
-      let root = do_excluding(path, nextCursor + 1, steps)
-      do_branch(path, cursor, nextCursor, root, neighbors)
+      let next_cursor = cursor + skip
+      let root = do_excluding(path, next_cursor + 1, steps)
+      do_branch(path, cursor, next_cursor, root, neighbors)
     }
 
     [Fork { skip, neighbor }] -> {
@@ -347,25 +347,25 @@ fn do_excluding(path: ByteArray, cursor: Int, proof: Proof) -> ByteArray {
     }
 
     [Fork { skip, neighbor }, ..steps] -> {
-      let nextCursor = cursor + skip
-      let root = do_excluding(path, nextCursor + 1, steps)
-      do_fork(path, cursor, nextCursor, root, neighbor)
+      let next_cursor = cursor + skip
+      let root = do_excluding(path, next_cursor + 1, steps)
+      do_fork(path, cursor, next_cursor, root, neighbor)
     }
 
     [Leaf { key, value, .. }] -> combine(suffix(key, cursor), value)
 
     [Leaf { skip, key, value }, ..steps] -> {
-      let nextCursor = cursor + skip
-      let root = do_excluding(path, nextCursor + 1, steps)
+      let next_cursor = cursor + skip
+      let root = do_excluding(path, next_cursor + 1, steps)
 
       let neighbor =
         Neighbor {
-          prefix: suffix(key, nextCursor + 1),
-          nibble: nibble(key, nextCursor),
+          prefix: suffix(key, next_cursor + 1),
+          nibble: nibble(key, next_cursor),
           root: value,
         }
 
-      do_fork(path, cursor, nextCursor, root, neighbor)
+      do_fork(path, cursor, next_cursor, root, neighbor)
     }
   }
 }
@@ -377,13 +377,13 @@ fn do_excluding(path: ByteArray, cursor: Int, proof: Proof) -> ByteArray {
 fn do_branch(
   path: ByteArray,
   cursor: Int,
-  nextCursor: Int,
+  next_cursor: Int,
   root: ByteArray,
   neighbors: ByteArray,
 ) -> ByteArray {
-  let branch = nibble(path, nextCursor)
+  let branch = nibble(path, next_cursor)
 
-  let prefix = nibbles(path, cursor, nextCursor)
+  let prefix = nibbles(path, cursor, next_cursor)
 
   combine(
     prefix,
@@ -401,13 +401,13 @@ fn do_branch(
 fn do_fork(
   path: ByteArray,
   cursor: Int,
-  nextCursor: Int,
+  next_cursor: Int,
   root: ByteArray,
   neighbor: Neighbor,
 ) -> ByteArray {
-  let branch = nibble(path, nextCursor)
+  let branch = nibble(path, next_cursor)
 
-  let prefix = nibbles(path, cursor, nextCursor)
+  let prefix = nibbles(path, cursor, next_cursor)
 
   expect branch != neighbor.nibble
 

--- a/on-chain/lib/aiken/merkle-patricia-forestry.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.ak
@@ -139,6 +139,17 @@ pub fn insert(
   MerklePatriciaForestry { root: including(key, value, proof) }
 }
 
+/// A version of 'insert' that unwraps the opaque arguments, to allow being exported.
+fn insert_ffi(
+  self: ByteArray,
+  key: ByteArray,
+  value: ByteArray,
+  proof: Proof,
+) -> ByteArray {
+  expect excluding(key, proof) == self
+  including(key, value, proof)
+}
+
 /// since | <code>1.0.0</code>
 /// ---   | ---
 ///
@@ -158,6 +169,17 @@ pub fn delete(
 ) -> MerklePatriciaForestry {
   expect including(key, value, proof) == self.root
   MerklePatriciaForestry { root: excluding(key, proof) }
+}
+
+/// A version of 'delete' that unwraps the opaque arguments, to allow being exported.
+pub fn delete_ffi(
+  self: ByteArray,
+  key: ByteArray,
+  value: ByteArray,
+  proof: Proof,
+) -> ByteArray {
+  expect including(key, value, proof) == self
+  excluding(key, proof)
 }
 
 /// since          | <code>1.1.0</code>

--- a/on-chain/lib/aiken/merkle-patricia-forestry.tests.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry.tests.ak
@@ -637,6 +637,19 @@ test example_fake_update() fail {
 
 // -------------------- Some notable cases
 
+test example_excluding_empty_proof(key via fuzz.bytearray_between(0, 32)) {
+  mpf.miss(mpf.empty, key, [])
+}
+
+test example_including_empty_proof(
+  (key, value) via fuzz.both(
+    fuzz.bytearray_between(0, 32),
+    fuzz.bytearray_between(0, 32),
+  ),
+) fail {
+  mpf.has(mpf.empty, key, value, [])
+}
+
 test example_insert_whatever() {
   let root = mpf.insert(without_kiwi, kiwi, "foo", proof_kiwi)
   root != trie

--- a/on-chain/lib/aiken/merkle-patricia-forestry/helpers.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry/helpers.ak
@@ -3,7 +3,7 @@
 //// This module contains internal functions used by the library. They are only
 //// exposed for internal testing and module splitting.
 
-use aiken/builtin.{blake2b_256, index_bytearray}
+use aiken/builtin.{blake2b_256}
 use aiken/primitive/bytearray
 
 // -----------------------------------------------------------------------------
@@ -49,8 +49,8 @@ pub fn nibbles(path: ByteArray, start: Int, end: Int) -> ByteArray {
 
 pub fn nibble(self: ByteArray, index: Int) -> Int {
   if index % 2 == 0 {
-    index_bytearray(self, index / 2) / 16
+    bytearray.at(self, index / 2) / 16
   } else {
-    index_bytearray(self, index / 2) % 16
+    bytearray.at(self, index / 2) % 16
   }
 }

--- a/on-chain/lib/aiken/merkle-patricia-forestry/merkling.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry/merkling.ak
@@ -67,17 +67,23 @@ pub fn merkle_4(
   neighbor_1: ByteArray,
 ) -> ByteArray {
   if branch <= 1 {
-    combine(merkle_2(branch, root, neighbor_1), neighbor_2)
+    combine(
+      if branch == 0 {
+        combine(root, neighbor_1)
+      } else {
+        combine(neighbor_1, root)
+      },
+      neighbor_2,
+    )
   } else {
-    combine(neighbor_2, merkle_2(branch - 2, root, neighbor_1))
-  }
-}
-
-pub fn merkle_2(branch: Int, root: ByteArray, neighbor: ByteArray) -> ByteArray {
-  if branch <= 0 {
-    combine(root, neighbor)
-  } else {
-    combine(neighbor, root)
+    combine(
+      neighbor_2,
+      if branch == 2 {
+        combine(root, neighbor_1)
+      } else {
+        combine(neighbor_1, root)
+      },
+    )
   }
 }
 
@@ -91,8 +97,8 @@ pub fn sparse_merkle_16(
   neighbor: Int,
   neighbor_hash: ByteArray,
 ) -> ByteArray {
-  if me < 8 {
-    if neighbor < 8 {
+  if me <= 7 {
+    if neighbor <= 7 {
       combine(
         sparse_merkle_8(me, me_hash, neighbor, neighbor_hash),
         null_hash_8,
@@ -130,8 +136,8 @@ pub fn sparse_merkle_8(
   neighbor: Int,
   neighbor_hash: ByteArray,
 ) -> ByteArray {
-  if me < 4 {
-    if neighbor < 4 {
+  if me <= 3 {
+    if neighbor <= 3 {
       combine(
         sparse_merkle_4(me, me_hash, neighbor, neighbor_hash),
         null_hash_4,
@@ -163,23 +169,31 @@ pub fn sparse_merkle_4(
   neighbor: Int,
   neighbor_hash: ByteArray,
 ) -> ByteArray {
-  if me < 2 {
-    if neighbor < 2 {
-      combine(merkle_2(me, me_hash, neighbor_hash), null_hash_2)
+  let combine_me =
+    if me % 2 == 0 {
+      combine(me_hash, _)
     } else {
-      combine(
-        merkle_2(me, me_hash, null_hash),
-        merkle_2(neighbor - 2, neighbor_hash, null_hash),
-      )
+      combine(_, me_hash)
+    }
+
+  let combine_neighbor =
+    if neighbor % 2 == 0 {
+      combine(neighbor_hash, _)
+    } else {
+      combine(_, neighbor_hash)
+    }
+
+  if me <= 1 {
+    if neighbor <= 1 {
+      combine(combine_me(neighbor_hash), null_hash_2)
+    } else {
+      combine(combine_me(null_hash), combine_neighbor(null_hash))
     }
   } else {
     if neighbor >= 2 {
-      combine(null_hash_2, merkle_2(me - 2, me_hash, neighbor_hash))
+      combine(null_hash_2, combine_me(neighbor_hash))
     } else {
-      combine(
-        merkle_2(neighbor, neighbor_hash, null_hash),
-        merkle_2(me - 2, me_hash, null_hash),
-      )
+      combine(combine_neighbor(null_hash), combine_me(null_hash))
     }
   }
 }

--- a/on-chain/lib/aiken/merkle-patricia-forestry/merkling.ak
+++ b/on-chain/lib/aiken/merkle-patricia-forestry/merkling.ak
@@ -87,19 +87,22 @@ pub fn merkle_2(branch: Int, root: ByteArray, neighbor: ByteArray) -> ByteArray 
 
 pub fn sparse_merkle_16(
   me: Int,
-  meHash: ByteArray,
+  me_hash: ByteArray,
   neighbor: Int,
-  neighborHash: ByteArray,
+  neighbor_hash: ByteArray,
 ) -> ByteArray {
   if me < 8 {
     if neighbor < 8 {
-      combine(sparse_merkle_8(me, meHash, neighbor, neighborHash), null_hash_8)
+      combine(
+        sparse_merkle_8(me, me_hash, neighbor, neighbor_hash),
+        null_hash_8,
+      )
     } else {
       combine(
-        merkle_8(me, meHash, null_hash_4, null_hash_2, null_hash),
+        merkle_8(me, me_hash, null_hash_4, null_hash_2, null_hash),
         merkle_8(
           neighbor - 8,
-          neighborHash,
+          neighbor_hash,
           null_hash_4,
           null_hash_2,
           null_hash,
@@ -110,12 +113,12 @@ pub fn sparse_merkle_16(
     if neighbor >= 8 {
       combine(
         null_hash_8,
-        sparse_merkle_8(me - 8, meHash, neighbor - 8, neighborHash),
+        sparse_merkle_8(me - 8, me_hash, neighbor - 8, neighbor_hash),
       )
     } else {
       combine(
-        merkle_8(neighbor, neighborHash, null_hash_4, null_hash_2, null_hash),
-        merkle_8(me - 8, meHash, null_hash_4, null_hash_2, null_hash),
+        merkle_8(neighbor, neighbor_hash, null_hash_4, null_hash_2, null_hash),
+        merkle_8(me - 8, me_hash, null_hash_4, null_hash_2, null_hash),
       )
     }
   }
@@ -123,29 +126,32 @@ pub fn sparse_merkle_16(
 
 pub fn sparse_merkle_8(
   me: Int,
-  meHash: ByteArray,
+  me_hash: ByteArray,
   neighbor: Int,
-  neighborHash: ByteArray,
+  neighbor_hash: ByteArray,
 ) -> ByteArray {
   if me < 4 {
     if neighbor < 4 {
-      combine(sparse_merkle_4(me, meHash, neighbor, neighborHash), null_hash_4)
+      combine(
+        sparse_merkle_4(me, me_hash, neighbor, neighbor_hash),
+        null_hash_4,
+      )
     } else {
       combine(
-        merkle_4(me, meHash, null_hash_2, null_hash),
-        merkle_4(neighbor - 4, neighborHash, null_hash_2, null_hash),
+        merkle_4(me, me_hash, null_hash_2, null_hash),
+        merkle_4(neighbor - 4, neighbor_hash, null_hash_2, null_hash),
       )
     }
   } else {
     if neighbor >= 4 {
       combine(
         null_hash_4,
-        sparse_merkle_4(me - 4, meHash, neighbor - 4, neighborHash),
+        sparse_merkle_4(me - 4, me_hash, neighbor - 4, neighbor_hash),
       )
     } else {
       combine(
-        merkle_4(neighbor, neighborHash, null_hash_2, null_hash),
-        merkle_4(me - 4, meHash, null_hash_2, null_hash),
+        merkle_4(neighbor, neighbor_hash, null_hash_2, null_hash),
+        merkle_4(me - 4, me_hash, null_hash_2, null_hash),
       )
     }
   }
@@ -153,26 +159,26 @@ pub fn sparse_merkle_8(
 
 pub fn sparse_merkle_4(
   me: Int,
-  meHash: ByteArray,
+  me_hash: ByteArray,
   neighbor: Int,
-  neighborHash: ByteArray,
+  neighbor_hash: ByteArray,
 ) -> ByteArray {
   if me < 2 {
     if neighbor < 2 {
-      combine(merkle_2(me, meHash, neighborHash), null_hash_2)
+      combine(merkle_2(me, me_hash, neighbor_hash), null_hash_2)
     } else {
       combine(
-        merkle_2(me, meHash, null_hash),
-        merkle_2(neighbor - 2, neighborHash, null_hash),
+        merkle_2(me, me_hash, null_hash),
+        merkle_2(neighbor - 2, neighbor_hash, null_hash),
       )
     }
   } else {
     if neighbor >= 2 {
-      combine(null_hash_2, merkle_2(me - 2, meHash, neighborHash))
+      combine(null_hash_2, merkle_2(me - 2, me_hash, neighbor_hash))
     } else {
       combine(
-        merkle_2(neighbor, neighborHash, null_hash),
-        merkle_2(me - 2, meHash, null_hash),
+        merkle_2(neighbor, neighbor_hash, null_hash),
+        merkle_2(me - 2, me_hash, null_hash),
       )
     }
   }


### PR DESCRIPTION
Make it easier to build non-membership proofs. 

- On-chain: this is relatively straightforward, as it suffices to verify a proof in exclusion mode. 

- Off-chain: the difficulty lies therefore off-chain; where we must obtain such a proof. Yet, the library only provides way to build proofs for inserted elements and we don't want to needlessly insert / remove something in the database without proper isolation (what if there's a crash between the insert/remove?). 
 
  The strategy remains however _that_: insert an element, building a proof, remove the element. But all that done atomically and without the hassle of providing a `value`. This creates a proof that can only be used in exclusion and allows to check for non-membership. 
 

TODO: 

- [x] Update README's doc
- [ ] On-chain helpers for non-membership
- [ ] Some additional proptest to ensure soundness of the approach